### PR TITLE
Feature/api return types

### DIFF
--- a/Nbic.References.Tests/ReferenceControllerTests.cs
+++ b/Nbic.References.Tests/ReferenceControllerTests.cs
@@ -13,6 +13,8 @@ using Index = Nbic.References.Infrastructure.Services.Indexing.Index;
 
 namespace Nbic.References.Tests;
 
+using Azure;
+using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 
 public class ReferenceControllerTests
@@ -40,7 +42,11 @@ public class ReferenceControllerTests
                 var count = (await service.GetCount()).Value;
                 Assert.Equal(1, count);
                 var all = await service.GetAll();
-                Assert.Single(all.ToArray());
+                if (all.Result is OkObjectResult okResult)
+                {
+                    var list =okResult.Value as List<Reference>;
+                    Assert.Single(list.ToArray());
+                }
             }
         }
         finally
@@ -83,7 +89,11 @@ public class ReferenceControllerTests
                 var count = (await service.GetCount()).Value;
                 Assert.Equal(1, count);
                 var all = await service.GetAll();
-                Assert.Single(all.ToArray());
+                if (all.Result is OkObjectResult okResult)
+                {
+                    var list = okResult.Value as List<Reference>;
+                    Assert.Single(list.ToArray());
+                }
             }
         }
         finally
@@ -115,7 +125,11 @@ public class ReferenceControllerTests
                 service.Delete(id);
 
                 var all = await service.GetAll();
-                Assert.Empty(all.ToArray());
+                if (all.Result is OkObjectResult okResult)
+                {
+                    var list = okResult.Value as List<Reference>;
+                    Assert.Single(list.ToArray());
+                }
             }
         }
         finally
@@ -153,7 +167,11 @@ public class ReferenceControllerTests
                 Assert.Throws<InvalidOperationException>(() => service.Delete(id));
 
                 var all = await service.GetAll();
-                Assert.Single(all.ToArray());
+                if (all.Result is OkObjectResult okResult)
+                {
+                    var list =okResult.Value as List<Reference>;
+                    Assert.Single(list.ToArray());
+                }
             }
         }
         finally
@@ -191,7 +209,11 @@ public class ReferenceControllerTests
                 Assert.Throws<InvalidOperationException>(() => service.Delete(id));
 
                 var all = await service.GetAll();
-                Assert.Single(all.ToArray());
+                if (all.Result is OkObjectResult okResult)
+                {
+                    var list = okResult.Value as List<Reference>;
+                    Assert.Single(list.ToArray());
+                }
             }
         }
         finally
@@ -439,7 +461,7 @@ public class ReferenceControllerTests
     }
 
     [Fact]
-    public async Task CanPostBulkReferences()
+    public async void CanPostBulkReferences()
     {
         GetInMemoryDb(out var connection, out var options);
 
@@ -489,7 +511,7 @@ public class ReferenceControllerTests
     }
 
     [Fact]
-    public async Task CanNotPostReferencesWithIdenticalId()
+    public async void CanNotPostReferencesWithIdenticalId()
     {
         GetInMemoryDb(out var connection, out var options);
 

--- a/Nbic.References.Tests/ReferenceControllerTests.cs
+++ b/Nbic.References.Tests/ReferenceControllerTests.cs
@@ -37,14 +37,26 @@ public class ReferenceControllerTests
             await using (var context = new ReferencesDbContext(options))
             {
                 var service = GetReferencesController(context, index);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
-                var count = (await service.GetCount()).Value;
-                Assert.Equal(1, count);
-                var all = await service.GetAll();
-                if (all.Result is OkObjectResult okResult)
+
+                var response = await service.Get(id);     
+                if (response.Result is OkObjectResult okResult)
                 {
-                    var list =okResult.Value as List<Reference>;
+                    var reference = okResult.Value as Reference;
+                    Assert.Equal(id, reference.Id);
+                }
+
+                var response1 = await service.GetCount();
+                if (response1.Result is OkObjectResult okResult1)
+                {
+                    var count1 = okResult1.Value as int?;
+                    Assert.Equal(1, count1);
+
+                }
+
+                var all = await service.GetAll();
+                if (all.Result is OkObjectResult okResult2)
+                {
+                    var list =okResult2.Value as List<Reference>;
                     Assert.Single(list.ToArray());
                 }
             }
@@ -84,14 +96,25 @@ public class ReferenceControllerTests
             await using (var context = new ReferencesDbContext(options))
             {
                 var service = GetReferencesController(context, index);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
-                var count = (await service.GetCount()).Value;
-                Assert.Equal(1, count);
-                var all = await service.GetAll();
-                if (all.Result is OkObjectResult okResult)
+
+                var response = await service.Get(id);
+                if (response.Result is OkObjectResult okResult)
                 {
-                    var list = okResult.Value as List<Reference>;
+                    var reference = okResult.Value as Reference;
+                    Assert.Equal(id, reference.Id);
+                }
+
+                var response1 = await service.GetCount();
+                if (response1.Result is OkObjectResult okResult1)
+                {
+                    var count1 = okResult1.Value as int?;
+                    Assert.Equal(1, count1);
+                }
+
+                var all = await service.GetAll();
+                if (all.Result is OkObjectResult okResult2)
+                {
+                    var list = okResult2.Value as List<Reference>;
                     Assert.Single(list.ToArray());
                 }
             }
@@ -120,16 +143,23 @@ public class ReferenceControllerTests
             await using (var context = new ReferencesDbContext(options))
             {
                 var service = GetReferencesController(context, index);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
-                service.Delete(id);
+                var response = await service.Get(id);
+                //Assert.Equal(id, response.Value.Id);
+                if (response.Result is OkObjectResult okResult)
+                {
+                    var reference = okResult.Value as Reference;
+                    Assert.Equal(id, reference.Id);
+                }
+                
 
                 var all = await service.GetAll();
-                if (all.Result is OkObjectResult okResult)
+                if (all.Result is OkObjectResult okResult1)
                 {
-                    var list = okResult.Value as List<Reference>;
+                    var list = okResult1.Value as List<Reference>;
                     Assert.Single(list.ToArray());
                 }
+
+                service.Delete(id);
             }
         }
         finally
@@ -161,15 +191,20 @@ public class ReferenceControllerTests
             await using (var context = new ReferencesDbContext(options))
             {
                 var service = GetReferencesController(context, index);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
+                var response = await service.Get(id);
+    
+                if (response.Result is OkObjectResult okResult)
+                {
+                    var reference = okResult.Value as Reference;
+                    Assert.Equal(id, reference.Id);
+                }
 
                 Assert.Throws<InvalidOperationException>(() => service.Delete(id));
 
                 var all = await service.GetAll();
-                if (all.Result is OkObjectResult okResult)
+                if (all.Result is OkObjectResult okResult1)
                 {
-                    var list =okResult.Value as List<Reference>;
+                    var list =okResult1.Value as List<Reference>;
                     Assert.Single(list.ToArray());
                 }
             }
@@ -203,15 +238,19 @@ public class ReferenceControllerTests
             await using (var context = new ReferencesDbContext(options))
             {
                 var service = GetReferencesController(context, index);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
+                var response = await service.Get(id);
 
+                if (response.Result is OkObjectResult okResult)
+                {
+                    var reference = okResult.Value as Reference;
+                    Assert.Equal(id, reference.Id);
+                }
                 Assert.Throws<InvalidOperationException>(() => service.Delete(id));
 
                 var all = await service.GetAll();
-                if (all.Result is OkObjectResult okResult)
+                if (all.Result is OkObjectResult okResult1)
                 {
-                    var list = okResult.Value as List<Reference>;
+                    var list = okResult1.Value as List<Reference>;
                     Assert.Single(list.ToArray());
                 }
             }
@@ -374,29 +413,53 @@ public class ReferenceControllerTests
             {
                 Assert.Equal(1, context.Reference.Count());
                 var service = GetReferencesController(context, index);
-                var getit = await service.Get(reference.Id);
-                var it = getit.Value;
+                var response = await service.Get(reference.Id);
+                if (response.Result is OkObjectResult okResult)
+                {
+                    var reference1 = okResult.Value as Reference;
 
-                Assert.Equal(it.Year, replacementReference.Year);
-                Assert.Equal(it.Volume, replacementReference.Volume);
-                //Assert.Equal(it.ApplicationId, replacementReference.ApplicationId);
-                Assert.Equal(it.Author, replacementReference.Author);
-                Assert.Equal(it.Bibliography, replacementReference.Bibliography);
-                //Assert.Equal(it.EditDate, replacementReference.EditDate);
-                Assert.Equal(it.Firstname, replacementReference.Firstname);
-                //Assert.Equal(it.Id, replacementReference.Id);
-                Assert.Equal(it.ReferenceString, replacementReference.ReferenceString);
-                Assert.Equal(it.Journal, replacementReference.Journal);
-                Assert.Equal(it.Lastname, replacementReference.Lastname);
-                Assert.Equal(it.Middlename, replacementReference.Middlename);
-                Assert.Equal(it.Pages, replacementReference.Pages);
-                Assert.Single(it.ReferenceUsage.ToArray());
-                Assert.Equal(it.ReferenceUsage.First().ApplicationId,
-                    replacementReference.ReferenceUsage.First().ApplicationId);
-                Assert.Equal(it.Summary, replacementReference.Summary);
-                Assert.Equal(it.Title, replacementReference.Title);
-                Assert.Equal(it.Url, replacementReference.Url);
-                Assert.Equal(it.UserId, replacementReference.UserId);
+                    Assert.Equal(reference1.Year, replacementReference.Year);
+                    Assert.Equal(reference1.Volume, replacementReference.Volume);
+                    Assert.Equal(reference1.ApplicationId, replacementReference.ApplicationId);
+                    Assert.Equal(reference1.Author, replacementReference.Author);
+                    Assert.Equal(reference1.Bibliography, replacementReference.Bibliography);
+                    Assert.True(Math.Abs((reference1.EditDate - replacementReference.EditDate).TotalMilliseconds) < 1000, $"Expected: {replacementReference.EditDate}, Actual: {reference1.EditDate}");
+
+                    Assert.Equal(reference1.Firstname, replacementReference.Firstname);
+                    Assert.Equal(reference1.Id, replacementReference.Id);
+                    Assert.Equal(reference1.ReferenceString, replacementReference.ReferenceString);
+                    Assert.Equal(reference1.Journal, replacementReference.Journal);
+                    Assert.Equal(reference1.Lastname, replacementReference.Lastname);
+                    Assert.Equal(reference1.Middlename, replacementReference.Middlename);
+                    Assert.Equal(reference1.Pages, replacementReference.Pages);
+                    Assert.Single(reference1.ReferenceUsage.ToArray());
+                    Assert.Equal(reference1.ReferenceUsage.First().ApplicationId,replacementReference.ReferenceUsage.First().ApplicationId);
+                    Assert.Equal(reference1.Summary, replacementReference.Summary);
+                    Assert.Equal(reference1.Title, replacementReference.Title);
+                    Assert.Equal(reference1.Url, replacementReference.Url);
+                    Assert.Equal(reference1.UserId, replacementReference.UserId);
+                }
+
+                //Assert.Equal(it.Year, replacementReference.Year);
+                //Assert.Equal(it.Volume, replacementReference.Volume);
+                ////Assert.Equal(it.ApplicationId, replacementReference.ApplicationId);
+                //Assert.Equal(it.Author, replacementReference.Author);
+                //Assert.Equal(it.Bibliography, replacementReference.Bibliography);
+                ////Assert.Equal(it.EditDate, replacementReference.EditDate);
+                //Assert.Equal(it.Firstname, replacementReference.Firstname);
+                ////Assert.Equal(it.Id, replacementReference.Id);
+                //Assert.Equal(it.ReferenceString, replacementReference.ReferenceString);
+                //Assert.Equal(it.Journal, replacementReference.Journal);
+                //Assert.Equal(it.Lastname, replacementReference.Lastname);
+                //Assert.Equal(it.Middlename, replacementReference.Middlename);
+                //Assert.Equal(it.Pages, replacementReference.Pages);
+                //Assert.Single(it.ReferenceUsage.ToArray());
+                //Assert.Equal(it.ReferenceUsage.First().ApplicationId,
+                //    replacementReference.ReferenceUsage.First().ApplicationId);
+                //Assert.Equal(it.Summary, replacementReference.Summary);
+                //Assert.Equal(it.Title, replacementReference.Title);
+                //Assert.Equal(it.Url, replacementReference.Url);
+                //Assert.Equal(it.UserId, replacementReference.UserId);
             }
 
             var replacementReference2 = new Reference
@@ -429,29 +492,32 @@ public class ReferenceControllerTests
             {
                 Assert.Equal(1, context.Reference.Count());
                 var service = GetReferencesController(context, index);
-                var getit = await service.Get(reference.Id);
-                var it = getit.Value;
+                var response = await service.Get(reference.Id);
+                if (response.Result is OkObjectResult okResult)
+                {
+                    var reference1 = okResult.Value as Reference;
 
-                Assert.Equal(it.Year, replacementReference2.Year);
-                Assert.Equal(it.Volume, replacementReference2.Volume);
-                //Assert.Equal(it.ApplicationId, replacementReference.ApplicationId);
-                Assert.Equal(it.Author, replacementReference2.Author);
-                Assert.Equal(it.Bibliography, replacementReference2.Bibliography);
-                //Assert.Equal(it.EditDate, replacementReference.EditDate);
-                Assert.Equal(it.Firstname, replacementReference2.Firstname);
-                //Assert.Equal(it.Id, replacementReference.Id);
-                Assert.Equal(it.ReferenceString, replacementReference2.ReferenceString);
-                Assert.Equal(it.Journal, replacementReference2.Journal);
-                Assert.Equal(it.Lastname, replacementReference2.Lastname);
-                Assert.Equal(it.Middlename, replacementReference2.Middlename);
-                Assert.Equal(it.Pages, replacementReference2.Pages);
-                Assert.Single(it.ReferenceUsage.ToArray());
-                Assert.Equal(it.ReferenceUsage.First().ApplicationId,
-                    replacementReference.ReferenceUsage.First().ApplicationId);
-                Assert.Equal(it.Summary, replacementReference2.Summary);
-                Assert.Equal(it.Title, replacementReference2.Title);
-                Assert.Equal(it.Url, replacementReference2.Url);
-                Assert.Equal(it.UserId, replacementReference2.UserId);
+                    Assert.Equal(reference1.Year, replacementReference2.Year);
+                    Assert.Equal(reference1.Volume, replacementReference2.Volume);
+                    //Assert.Equal(reference1.ApplicationId, replacementReference.ApplicationId);
+                    Assert.Equal(reference1.Author, replacementReference2.Author);
+                    Assert.Equal(reference1.Bibliography, replacementReference2.Bibliography);
+                    //Assert.Equal(reference1.EditDate, replacementReference.EditDate);
+                    Assert.Equal(reference1.Firstname, replacementReference2.Firstname);
+                    //Assert.Equal(reference1.Id, replacementReference.Id);
+                    Assert.Equal(reference1.ReferenceString, replacementReference2.ReferenceString);
+                    Assert.Equal(reference1.Journal, replacementReference2.Journal);
+                    Assert.Equal(reference1.Lastname, replacementReference2.Lastname);
+                    Assert.Equal(reference1.Middlename, replacementReference2.Middlename);
+                    Assert.Equal(reference1.Pages, replacementReference2.Pages);
+                    Assert.Single(reference1.ReferenceUsage.ToArray());
+                    Assert.Equal(reference1.ReferenceUsage.First().ApplicationId,
+                        replacementReference.ReferenceUsage.First().ApplicationId);
+                    Assert.Equal(reference1.Summary, replacementReference2.Summary);
+                    Assert.Equal(reference1.Title, replacementReference2.Title);
+                    Assert.Equal(reference1.Url, replacementReference2.Url);
+                    Assert.Equal(reference1.UserId, replacementReference2.UserId);
+                }
             }
         }
         finally

--- a/Nbic.References.Tests/ReferenceUsageControllerTests.cs
+++ b/Nbic.References.Tests/ReferenceUsageControllerTests.cs
@@ -13,9 +13,7 @@ using Index = Nbic.References.Infrastructure.Services.Indexing.Index;
 namespace Nbic.References.Tests;
 
 using System.Collections.Generic;
-
 using Microsoft.AspNetCore.Mvc;
-using Index = Index;
 
 public class ReferenceUsageControllerTests
 {
@@ -27,7 +25,7 @@ public class ReferenceUsageControllerTests
     {
         return new ReferenceUsageController(new ReferenceUsageRepository(context));
     }
-    
+
     [Fact]
     public async Task CanPostReferenceAndGetReferenceUsages()
     {
@@ -54,12 +52,26 @@ public class ReferenceUsageControllerTests
             {
                 var usageService = GetReferencesUsageController(context);
 
-                var count = (await usageService.GetCount()).Value;
-                Assert.Equal(1, count);
-                var all = await usageService.GetAll();
-                Assert.Single(all);
-                var them = await usageService.Get(id);
-                Assert.Single(them);
+                var response = await usageService.GetCount();
+                if (response.Result is OkObjectResult okResult)
+                {
+                    var count1 = okResult.Value as int?;
+                    Assert.Equal(1, count1);
+                }
+
+                var allResult = await usageService.GetAll();
+                if (allResult.Result is OkObjectResult allOkResult)
+                {
+                    var all = allOkResult.Value as List<ReferenceUsage>;
+                    Assert.Single(all);
+                }
+
+                var themResult = await usageService.Get(id);
+                if (themResult.Result is OkObjectResult themOkResult)
+                {
+                    var them = themOkResult.Value as List<ReferenceUsage>;
+                    Assert.Single(them);
+                }
             }
         }
         finally
@@ -95,8 +107,14 @@ public class ReferenceUsageControllerTests
                 var service = GetReferencesController(context, index);
                 var usageService = GetReferencesUsageController(context);
                 usageService.DeleteAllUsages(id);
-                var all = await usageService.GetAll();
-                Assert.Empty(all);
+
+                var allResult = await usageService.GetAll();
+                if (allResult.Result is OkObjectResult allOkResult)
+                {
+                    var all = allOkResult.Value as List<ReferenceUsage>;
+                    Assert.Empty(all);
+                }
+
                 var response = await service.Get(id);
                 if (response.Result is OkObjectResult okObjectResult)
                 {
@@ -145,15 +163,20 @@ public class ReferenceUsageControllerTests
                 var service = GetReferencesController(context, index);
                 var usageService = GetReferencesUsageController(context);
                 usageService.DeleteUsage(id, 1, new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3"));
-                var all = await usageService.GetAll();
-                Assert.Single(all);
+
+                var allResult = await usageService.GetAll();
+                if (allResult.Result is OkObjectResult allOkResult)
+                {
+                    var all = allOkResult.Value as List<ReferenceUsage>;
+                    Assert.Single(all);
+                }
+
                 var response = await service.Get(id);
                 if (response.Result is OkObjectResult okObjectResult)
                 {
                     Assert.Equal(id, ((Reference)okObjectResult.Value).Id);
                     Assert.Single(((Reference)okObjectResult.Value).ReferenceUsage);
                 }
-          
 
                 // and should not be found
                 var response1 = await service.Get(id);
@@ -191,8 +214,14 @@ public class ReferenceUsageControllerTests
                 var service = GetReferencesController(context, index);
                 var usageService = GetReferencesUsageController(context);
                 await usageService.Post(new ReferenceUsage { ApplicationId = 3, ReferenceId = id, UserId = new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3") });
-                var all = await usageService.GetAll();
-                Assert.Equal(3, all.Count);
+
+                var allResult = await usageService.GetAll();
+                if (allResult.Result is OkObjectResult allOkResult)
+                {
+                    var all = allOkResult.Value as List<ReferenceUsage>;
+                    Assert.Equal(3, all.Count);
+                }
+
                 var response = await service.Get(id);
                 if (response.Result is OkObjectResult okObjectResult)
                 {
@@ -245,20 +274,27 @@ public class ReferenceUsageControllerTests
             {
                 var service = GetReferencesController(context, index);
                 var usageService = GetReferencesUsageController(context);
-                await usageService.Post([
-                    new()
+                await usageService.Post(new[]
+                {
+                    new ReferenceUsage
                     {
                         ApplicationId = 3, ReferenceId = id,
                         UserId = new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3")
                     },
-                    new()
+                    new ReferenceUsage
                     {
                         ApplicationId = 3, ReferenceId = id2,
                         UserId = new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3")
                     }
-                ]);
-                var all = await usageService.GetAll();
-                Assert.Equal(6, all.Count);
+                });
+
+                var allResult = await usageService.GetAll();
+                if (allResult.Result is OkObjectResult allOkResult)
+                {
+                    var all = allOkResult.Value as List<ReferenceUsage>;
+                    Assert.Equal(6, all.Count);
+                }
+
                 var response = await service.Get(id);
                 if (response.Result is OkObjectResult okObjectResult)
                 {
@@ -279,6 +315,7 @@ public class ReferenceUsageControllerTests
             connection.Close();
         }
     }
+
     [Fact]
     public async Task AddReferenceUsageToNotExistingReferenceShouldNotFail()
     {
@@ -318,25 +355,32 @@ public class ReferenceUsageControllerTests
             {
                 var service = GetReferencesController(context, index);
                 var usageService = GetReferencesUsageController(context);
-                await usageService.Post([
-                    new()
+                await usageService.Post(new[]
+                {
+                    new ReferenceUsage
                     {
                         ApplicationId = 3, ReferenceId = id,
                         UserId = new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3")
                     },
-                    new()
+                    new ReferenceUsage
                     {
                         ApplicationId = 3, ReferenceId = id2,
                         UserId = new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3")
                     },
-                    new()
+                    new ReferenceUsage
                     {
                         ApplicationId = 3, ReferenceId = id3,
                         UserId = new Guid("3ed89222-de9a-4df3-9e95-87f7fcac67a3")
                     }
-                ]);
-                var all = await usageService.GetAll();
-                Assert.Equal(6, all.Count);
+                });
+
+                var allResult = await usageService.GetAll();
+                if (allResult.Result is OkObjectResult allOkResult)
+                {
+                    var all = allOkResult.Value as List<ReferenceUsage>;
+                    Assert.Equal(6, all.Count);
+                }
+
                 var response = await service.Get(id);
                 if (response.Result is OkObjectResult okObjectResult)
                 {
@@ -345,10 +389,10 @@ public class ReferenceUsageControllerTests
                 }
 
                 var response2 = await service.Get(id2);
-                if (response2.Result is OkObjectResult okResult) 
-                { 
-                    Assert.Equal(id2, ((Reference)okResult.Value).Id); 
-                    Assert.Equal(3, ((Reference)okResult.Value).ReferenceUsage.Count); 
+                if (response2.Result is OkObjectResult okResult)
+                {
+                    Assert.Equal(id2, ((Reference)okResult.Value).Id);
+                    Assert.Equal(3, ((Reference)okResult.Value).ReferenceUsage.Count);
                 }
             }
         }
@@ -357,6 +401,7 @@ public class ReferenceUsageControllerTests
             connection.Close();
         }
     }
+
     [Fact]
     public async Task CanAddSingleDuplicateReferenceUsage()
     {
@@ -390,8 +435,14 @@ public class ReferenceUsageControllerTests
                     ReferenceId = id,
                     UserId = new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3")
                 });
-                var all = await usageService.GetAll();
-                Assert.Equal(2, all.Count);
+
+                var allResult = await usageService.GetAll();
+                if (allResult.Result is OkObjectResult allOkResult)
+                {
+                    var all = allOkResult.Value as List<ReferenceUsage>;
+                    Assert.Equal(2, all.Count);
+                }
+
                 var response = await service.Get(id);
                 if (response.Result is OkObjectResult okObjectResult)
                 {

--- a/Nbic.References.Tests/ReferenceUsageControllerTests.cs
+++ b/Nbic.References.Tests/ReferenceUsageControllerTests.cs
@@ -97,8 +97,12 @@ public class ReferenceUsageControllerTests
                 usageService.DeleteAllUsages(id);
                 var all = await usageService.GetAll();
                 Assert.Empty(all);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
+                var response = await service.Get(id);
+                if (response.Result is OkObjectResult okObjectResult)
+                {
+                    Assert.Equal(id, ((Reference)okObjectResult.Value).Id);
+                    Assert.Empty(((Reference)okObjectResult.Value).ReferenceUsage);
+                }
 
                 // now delete reference
                 service.Delete(id);
@@ -143,12 +147,21 @@ public class ReferenceUsageControllerTests
                 usageService.DeleteUsage(id, 1, new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3"));
                 var all = await usageService.GetAll();
                 Assert.Single(all);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
+                var response = await service.Get(id);
+                if (response.Result is OkObjectResult okObjectResult)
+                {
+                    Assert.Equal(id, ((Reference)okObjectResult.Value).Id);
+                    Assert.Single(((Reference)okObjectResult.Value).ReferenceUsage);
+                }
+          
 
                 // and should not be found
-                var result2 = await service.Get(id);
-                Assert.Single(result2.Value.ReferenceUsage);
+                var response1 = await service.Get(id);
+                if (response1.Result is OkObjectResult okObjectResult1)
+                {
+                    Assert.Equal(id, ((Reference)okObjectResult1.Value).Id);
+                    Assert.Single(((Reference)okObjectResult1.Value).ReferenceUsage);
+                }
             }
         }
         finally
@@ -180,9 +193,12 @@ public class ReferenceUsageControllerTests
                 await usageService.Post(new ReferenceUsage { ApplicationId = 3, ReferenceId = id, UserId = new Guid("3ed89222-de9a-4df3-9e95-67f7fcac67a3") });
                 var all = await usageService.GetAll();
                 Assert.Equal(3, all.Count);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
-                Assert.Equal(3, result.Value.ReferenceUsage.Count);
+                var response = await service.Get(id);
+                if (response.Result is OkObjectResult okObjectResult)
+                {
+                    Assert.Equal(id, ((Reference)okObjectResult.Value).Id);
+                    Assert.Equal(3, ((Reference)okObjectResult.Value).ReferenceUsage.Count);
+                }
             }
         }
         finally
@@ -243,12 +259,19 @@ public class ReferenceUsageControllerTests
                 ]);
                 var all = await usageService.GetAll();
                 Assert.Equal(6, all.Count);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
-                Assert.Equal(3, result.Value.ReferenceUsage.Count);
-                var result2 = await service.Get(id2);
-                Assert.Equal(id2, result2.Value.Id);
-                Assert.Equal(3, result2.Value.ReferenceUsage.Count);
+                var response = await service.Get(id);
+                if (response.Result is OkObjectResult okObjectResult)
+                {
+                    Assert.Equal(id, ((Reference)okObjectResult.Value).Id);
+                    Assert.Equal(3, ((Reference)okObjectResult.Value).ReferenceUsage.Count);
+                }
+
+                var response1 = await service.Get(id2);
+                if (response1.Result is OkObjectResult okResult)
+                {
+                    Assert.Equal(id2, ((Reference)okResult.Value).Id);
+                    Assert.Equal(3, ((Reference)okResult.Value).ReferenceUsage.Count);
+                }
             }
         }
         finally
@@ -314,12 +337,19 @@ public class ReferenceUsageControllerTests
                 ]);
                 var all = await usageService.GetAll();
                 Assert.Equal(6, all.Count);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
-                Assert.Equal(3, result.Value.ReferenceUsage.Count);
-                var result2 = await service.Get(id2);
-                Assert.Equal(id2, result2.Value.Id);
-                Assert.Equal(3, result2.Value.ReferenceUsage.Count);
+                var response = await service.Get(id);
+                if (response.Result is OkObjectResult okObjectResult)
+                {
+                    Assert.Equal(id, ((Reference)okObjectResult.Value).Id);
+                    Assert.Equal(3, ((Reference)okObjectResult.Value).ReferenceUsage.Count);
+                }
+
+                var response2 = await service.Get(id2);
+                if (response2.Result is OkObjectResult okResult) 
+                { 
+                    Assert.Equal(id2, ((Reference)okResult.Value).Id); 
+                    Assert.Equal(3, ((Reference)okResult.Value).ReferenceUsage.Count); 
+                }
             }
         }
         finally
@@ -362,9 +392,12 @@ public class ReferenceUsageControllerTests
                 });
                 var all = await usageService.GetAll();
                 Assert.Equal(2, all.Count);
-                var result = await service.Get(id);
-                Assert.Equal(id, result.Value.Id);
-                Assert.Equal(2, result.Value.ReferenceUsage.Count);
+                var response = await service.Get(id);
+                if (response.Result is OkObjectResult okObjectResult)
+                {
+                    Assert.Equal(id, ((Reference)okObjectResult.Value).Id);
+                    Assert.Equal(2, ((Reference)okObjectResult.Value).ReferenceUsage.Count);
+                }
             }
         }
         finally

--- a/Nbic.References/Controllers/ReferenceUsageController.cs
+++ b/Nbic.References/Controllers/ReferenceUsageController.cs
@@ -7,6 +7,7 @@ using Swashbuckle.AspNetCore.Annotations;
 namespace Nbic.References.Controllers;
 
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 
 [Route("api/[controller]")]
 [ApiController]
@@ -20,6 +21,8 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <param name="limit"></param>
     /// <returns></returns>
     [HttpGet]
+    [ProducesResponseType(typeof(List<ReferenceUsage>), 200)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<List<ReferenceUsage>>> GetAll(int offset = 0, int limit = 10)
     {
         var usages = await referenceUsageRepository.GetAll(offset, limit);
@@ -33,6 +36,9 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <returns></returns>
     [HttpGet]
     [Route("Reference/{id:guid}")]
+    [ProducesResponseType(typeof(List<ReferenceUsage>), 200)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<List<ReferenceUsage>>> Get(Guid id)
     {
         var usages = await referenceUsageRepository.GetFromReferenceId(id);
@@ -45,6 +51,7 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <returns></returns>
     [HttpGet]
     [Route("Count")]
+    [ProducesResponseType(typeof(int), 200)]
     public async Task<ActionResult<int>> GetCount()
     {
         var count = await referenceUsageRepository.CountAsync();
@@ -58,7 +65,9 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <returns></returns>
     [Authorize("WriteAccess")]
     [HttpDelete("{id:guid}")]
-    [ProducesResponseType(404)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public ActionResult DeleteAllUsages(Guid id)
     {
         try
@@ -82,6 +91,9 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <returns></returns>
     [Authorize("WriteAccess")]
     [HttpDelete("{id:guid},{applicationId:int},{userId:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public ActionResult DeleteUsage(Guid id, int applicationId, Guid userId)
     {
         try
@@ -103,6 +115,8 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <returns></returns>
     [Authorize("WriteAccess")]
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ReferenceUsage>> Post([FromBody] ReferenceUsage value)
     {
         if (value == null)
@@ -122,6 +136,8 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <returns></returns>
     [Authorize("WriteAccess")]
     [HttpPost("bulk")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<bool>> Post(ReferenceUsage[] value)
     {
         if (value == null)

--- a/Nbic.References/Controllers/ReferenceUsageController.cs
+++ b/Nbic.References/Controllers/ReferenceUsageController.cs
@@ -20,9 +20,10 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <param name="limit"></param>
     /// <returns></returns>
     [HttpGet]
-    public async Task<List<ReferenceUsage>> GetAll(int offset = 0, int limit = 10)
+    public async Task<ActionResult<List<ReferenceUsage>>> GetAll(int offset = 0, int limit = 10)
     {
-        return await referenceUsageRepository.GetAll(offset, limit);
+        var usages = await referenceUsageRepository.GetAll(offset, limit);
+        return Ok(usages);
     }
 
     /// <summary>
@@ -32,9 +33,10 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     /// <returns></returns>
     [HttpGet]
     [Route("Reference/{id:guid}")]
-    public async Task<List<ReferenceUsage>> Get(Guid id)
+    public async Task<ActionResult<List<ReferenceUsage>>> Get(Guid id)
     {
-        return await referenceUsageRepository.GetFromReferenceId(id);
+        var usages = await referenceUsageRepository.GetFromReferenceId(id);
+        return Ok(usages);
     }
 
     /// <summary>
@@ -45,7 +47,8 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     [Route("Count")]
     public async Task<ActionResult<int>> GetCount()
     {
-        return await referenceUsageRepository.CountAsync();
+        var count = await referenceUsageRepository.CountAsync();
+        return Ok(count);
     }
 
     /// <summary>
@@ -66,7 +69,7 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
         {
             return NotFound(e);
         }
-            
+
         return Ok();
     }
 
@@ -83,15 +86,14 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
     {
         try
         {
-            referenceUsageRepository.DeleteUsage(id, applicationId,userId);
+            referenceUsageRepository.DeleteUsage(id, applicationId, userId);
         }
         catch (NotFoundException e)
         {
             return NotFound(e);
         }
-            
-        return Ok();
 
+        return Ok();
     }
 
     /// <summary>
@@ -109,8 +111,8 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
         }
 
         await referenceUsageRepository.Add(value);
-            
-        return value;
+
+        return Ok(value);
     }
 
     /// <summary>
@@ -127,6 +129,7 @@ public class ReferenceUsageController(IReferenceUsageRepository referenceUsageRe
             return BadRequest("No data posted");
         }
 
-        return await referenceUsageRepository.AddRange(value);
+        var result = await referenceUsageRepository.AddRange(value);
+        return Ok(result);
     }
 }

--- a/Nbic.References/Controllers/ReferencesController.cs
+++ b/Nbic.References/Controllers/ReferencesController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -20,6 +21,8 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     /// <param name="search">Free text search</param>
     /// <returns></returns>
     [HttpGet]
+    [ProducesResponseType(typeof(List<Reference>), 200)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<List<Reference>>> GetAll(int offset = 0, int limit = 10, string search = null)
     {
         return Ok(await referencesRepository.Search(search, offset, limit));
@@ -31,6 +34,7 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     /// <returns>Number of references</returns>
     [HttpGet]
     [Route("Count")]
+    [ProducesResponseType(typeof(int), 200)]
     public async Task<ActionResult<int>> GetCount()
     {
         var count = await referencesRepository.CountAsync();
@@ -45,6 +49,7 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     [HttpGet]
     [Authorize("WriteAccess")]
     [Route("Reindex")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
     public ActionResult<bool> DoReindex()
     {
         referencesRepository.ReIndex();
@@ -58,6 +63,9 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     /// <param name="id"></param>
     /// <returns></returns>
     [HttpGet("{id:guid}")]
+    [ProducesResponseType(typeof(Reference), 200)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<Reference>> Get(Guid id)
     {
         var reference = await referencesRepository.Get(id);
@@ -74,6 +82,8 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     /// <returns></returns>
     [Authorize("WriteAccess")]
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Reference))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<Reference>> Post([FromBody] Reference value)
     {
         if (value == null)
@@ -103,6 +113,8 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     [Authorize("WriteAccess")]
     [HttpPost]
     [Route("Bulk")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> PostMany([FromBody] Reference[] values)
     {
         if (values == null || values.Length == 0)
@@ -130,6 +142,9 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     /// <returns></returns>
     [Authorize("WriteAccess")]
     [HttpPut("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Put(Guid id, [FromBody] Reference value)
     {
         if (value == null)
@@ -168,6 +183,9 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     [Authorize("WriteAccess")]
     [HttpDelete("{id:guid}")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "<Pending>")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public ActionResult Delete(Guid id)
     {
         try

--- a/Nbic.References/Controllers/ReferencesController.cs
+++ b/Nbic.References/Controllers/ReferencesController.cs
@@ -20,9 +20,9 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     /// <param name="search">Free text search</param>
     /// <returns></returns>
     [HttpGet]
-    public async Task<List<Reference>> GetAll(int offset = 0, int limit = 10, string search = null)
+    public async Task<ActionResult<List<Reference>>> GetAll(int offset = 0, int limit = 10, string search = null)
     {
-        return await referencesRepository.Search(search, offset, limit);
+        return Ok(await referencesRepository.Search(search, offset, limit));
     }
 
     /// <summary>
@@ -33,8 +33,10 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     [Route("Count")]
     public async Task<ActionResult<int>> GetCount()
     {
-        return await referencesRepository.CountAsync(); // _referencesDbContext.Reference.CountAsync().ConfigureAwait(false);
+        var count = await referencesRepository.CountAsync();
+        return Ok(count);
     }
+
 
     /// <summary>
     /// Administrative endpoint to force reindex of references
@@ -46,8 +48,9 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     public ActionResult<bool> DoReindex()
     {
         referencesRepository.ReIndex();
-        return true;
+        return Ok(true);
     }
+
 
     /// <summary>
     /// Get Reference by id
@@ -59,9 +62,10 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
     {
         var reference = await referencesRepository.Get(id);
         if (reference == null) return NotFound();
-            
-        return reference;
+
+        return Ok(reference);
     }
+
 
     /// <summary>
     /// Add a new reference
@@ -84,11 +88,12 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
         }
         catch (BadRequestException e)
         {
-            return BadRequest(e);
+            return BadRequest(e.Message);
         }
 
-        return newReference;
+        return Ok(newReference);
     }
+
 
     /// <summary>
     /// Add many references
@@ -110,11 +115,12 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
         }
         catch (BadRequestException e)
         {
-            return BadRequest(e);
+            return BadRequest(e.Message);
         }
-            
+
         return Ok();
     }
+
 
     /// <summary>
     /// Update a reference by Id
@@ -135,23 +141,24 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
         {
             value.Id = id;
         }
-            
+
         if (value.Id != id)
         {
             return BadRequest("Id on reference set and different...");
         }
-            
+
         try
         {
             await referencesRepository.Update(value);
         }
         catch (NotFoundException e)
         {
-            return NotFound(e);
+            return NotFound(e.Message);
         }
-           
+
         return Ok();
     }
+
 
     /// <summary>
     /// Delete a reference by Id
@@ -169,10 +176,9 @@ public class ReferencesController(IReferencesRepository referencesRepository) : 
         }
         catch (NotFoundException e)
         {
-            return NotFound(e);
+            return NotFound(e.Message);
         }
 
         return Ok();
-
     }
 }


### PR DESCRIPTION
- Changed return types on the referencesController methods using ActionsResult and specifying response types
- Changed return types on the referenceUsageController methods using ActionsResult and specifying response types
- Adjusted tests to pass when receiving ActionResult objects instead of primary types

Make sure no one is hurt! 

Do consumers of the API know of these changes?
